### PR TITLE
docs: add CHANGELOG for Phases 2 and 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## Phase 3 – Interactive Map Editing
+- Interactive canvas: select and drag components; positions auto-save.
+- Component CRUD: add new components, delete selected components.
+- Link mode: click source then target to create links; delete links from list.
+- Backend endpoints: POST/PATCH/DELETE for components; POST/DELETE for links.
+- API responses include link IDs to support UI deletion.
+
+## Phase 2 – AI Map Generation
+- Endpoint: POST /ai/generate-map (auth required) accepts { prompt }.
+- Validates strict JSON from OpenAI and persists maps, components (with evolution/visibility), and links.
+- DB migrations: maps.prompt, components.evolution/visibility, new links table.
+- Frontend: prompt input and basic canvas renderer.
+
+## Infrastructure & Docs
+- Express serves frontend; same-origin API calls.
+- .env example updated; DB password optional; no in-memory DB fallback.
+- Auto DB init/migrations at startup.


### PR DESCRIPTION
- Title: docs: add CHANGELOG for Phases 2 and 3
- Base: main
- Compare: docs-phase-3-release-notes
- Body:
    - Summary:
    - Adds CHANGELOG with release notes for Phase 2 (AI map generation) and Phase 3 (interactive editing).
- Highlights:
    - Phase 3: drag/position components with auto-save; add/delete components; create/delete links; backend CRUD endpoints; link IDs in API responses.
    - Phase 2: POST /ai/generate-map; strict JSON parsing; DB persistence for maps/components/links; basic canvas renderer; schema migrations.
    - Infra: Express serves frontend; .env example updated; optional DB password; no in-memory DB fallback; auto migrations on startup.
- Verification:
    - Set `OPENAI_API_KEY` and DB env vars.
    - Start server, login, generate a map, interactively edit components/links; reload to confirm persistence.
