### PR TITLE
feat(phase-4): AI chat with context and map manipulation; chat tables…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,8 @@
 - Interactive canvas: select and drag components to update positions (saves on mouseup).
 - Editing: add/delete components; link mode to create links via two clicks; list to delete links.
 - API added: `POST /maps/:id/components`, `PATCH /maps/:id/components/:componentId`, `DELETE /maps/:id/components/:componentId`, `POST /maps/:id/links`, `DELETE /maps/:id/links/:linkId`.
+
+## Phase 4 Notes
+- Chat: `GET /maps/:id/chat` returns messages for the user+map session; `POST /maps/:id/chat` sends a user message.
+- Context: backend includes map state and recent messages; model returns a reply and optional structured commands.
+- Commands supported: add/move/delete components; add/delete links. Commands are applied transactionally, then returned.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,11 @@ Visit http://localhost:3000 to use the app (Express serves the `frontend/` direc
 - Add components via the input + Add button; delete the selected component.
 - Link mode: toggle on, click source then target to create a link; delete links from the list under the canvas.
 - Endpoints used: `POST /maps/:id/components`, `PATCH /maps/:id/components/:componentId`, `DELETE /maps/:id/components/:componentId`, `POST /maps/:id/links`, `DELETE /maps/:id/links/:linkId`.
+
+## Phase 4: AI Chat & Map Manipulation
+- Chat panel per map with history; persists messages in DB.
+- Endpoints: `GET /maps/:id/chat` (history), `POST /maps/:id/chat` with `{ message }`.
+- Backend sends current map + recent messages as context to OpenAI and returns:
+  - Assistant reply text
+  - Optional map updates applied (add/move/delete components; add/delete links)
+- Requires `OPENAI_API_KEY`.

--- a/backend/db.js
+++ b/backend/db.js
@@ -65,6 +65,25 @@ async function initDb() {
       target_component_id INTEGER REFERENCES components(id)
     );
   `);
+
+  // Phase 4: chat sessions and messages
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS chat_sessions (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER REFERENCES users(id),
+      map_id INTEGER REFERENCES maps(id),
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS chat_messages (
+      id SERIAL PRIMARY KEY,
+      session_id INTEGER REFERENCES chat_sessions(id),
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
 }
 
 module.exports = {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -57,6 +57,15 @@
         <ul id="linksList" class="list-disc pl-5 text-sm"></ul>
       </div>
     </div>
+    <div class="space-y-2 border-t pt-4">
+      <h3 class="text-xl font-semibold">AI Chat</h3>
+      <div id="chatLog" class="border p-2 h-64 overflow-y-auto bg-gray-50 text-sm"></div>
+      <div class="flex gap-2 mt-2">
+        <input id="chatInput" class="flex-1 border p-1" placeholder="Ask the AI about this map..." />
+        <button id="sendChat" class="bg-blue-600 text-white px-3">Send</button>
+      </div>
+      <div id="chatStatus" class="text-sm text-gray-600 mt-1"></div>
+    </div>
   </div>
   <script>
     // Use same-origin API when served by Express
@@ -108,6 +117,7 @@
     let selectedComponentId = null;
     let dragState = null;
     let pendingLinkSourceId = null;
+    let sessionId = null;
 
     document.getElementById('generateMap').addEventListener('click', async () => {
       const prompt = document.getElementById('mapPrompt').value.trim();
@@ -128,6 +138,7 @@
         links = (data.links || []).map((l) => ({ ...l }));
         populateMaps();
         renderMap();
+        await loadChat();
       } catch (e) { status.textContent = 'Error: ' + e.message; }
     });
 
@@ -164,6 +175,7 @@
       const res = await fetch(API + `/maps/${id}`, { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
       const data = await res.json(); if (!res.ok) return;
       currentMapId = id; components = (data.components || []).map(c=>({ ...c })); links = (data.links || []).map(l=>({ ...l })); renderMap();
+      await loadChat();
     }
 
     function renderMap() {
@@ -260,6 +272,32 @@
       const toPixX = (e) => x0 + (x1 - x0) * clamp01(e); const toPixY = (v) => y0 - (y0 - y1) * clamp01(v);
       for (const c of components) { const cx = toPixX(c.evolution), cy = toPixY(c.visibility); const d2=(x-cx)*(x-cx)+(y-cy)*(y-cy); if (d2<=8*8) return c; }
       return null;
+    }
+
+    // Chat helpers
+    async function loadChat() {
+      if (!currentMapId) return;
+      const res = await fetch(API + `/maps/${currentMapId}/chat`, { headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') } });
+      if (!res.ok) return;
+      const data = await res.json(); sessionId = data.sessionId;
+      const log = document.getElementById('chatLog'); log.innerHTML = '';
+      for (const m of data.messages) appendChat(m.role, m.content);
+    }
+    document.getElementById('sendChat').addEventListener('click', async () => {
+      const input = document.getElementById('chatInput'); const txt = input.value.trim(); if (!txt || !currentMapId) return;
+      appendChat('user', txt); input.value = ''; document.getElementById('chatStatus').textContent = 'Thinking...';
+      const res = await fetch(API + `/maps/${currentMapId}/chat`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + localStorage.getItem('token') }, body: JSON.stringify({ message: txt }) });
+      const data = await res.json(); if (!res.ok) { document.getElementById('chatStatus').textContent = 'Error: ' + (data.error || 'chat failed'); return; }
+      document.getElementById('chatStatus').textContent = '';
+      appendChat('assistant', data.assistant || '');
+      if (Array.isArray(data.components)) components = data.components;
+      if (Array.isArray(data.links)) links = data.links;
+      renderMap();
+    });
+    function appendChat(role, content) {
+      const log = document.getElementById('chatLog'); const div = document.createElement('div');
+      div.className = role === 'assistant' ? 'mb-1 text-gray-800' : 'mb-1 text-gray-600';
+      div.textContent = `${role}: ${content}`; log.appendChild(div); log.scrollTop = log.scrollHeight;
     }
   </script>
 </body>


### PR DESCRIPTION
- Summary: Adds AI-powered chat to analyze and modify Wardley Maps. Persists chat history per map, sends map + recent messages as context, and applies structured AI “commands”
to update components and links.
Summary: Adds AI-powered chat to analyze and modify Wardley Maps. Persists chat history per map, sends map + recent messages as context, and applies structured AI “commands”
to update components and links.

- Backend:
    - Endpoints: GET /maps/:id/chat (fetch session + messages), POST /maps/:id/chat with { message }.
    - AI: chatOnMap in backend/ai.js with strict JSON contract (reply, commands[]).
    - Commands: add/move/delete components; add/delete links (applied transactionally).
    - Migrations: chat_sessions, chat_messages tables (auto-created in initDb()).
    - Responses: returns assistant reply and updated components/links.

- Frontend:
    - Chat panel: history view, input, send button, status line.
    - Behavior: loads chat on map select; sends message; appends assistant reply; re-renders canvas if map changed.
    - Same-origin API; no additional server required.

- Config:
    - Requires OPENAI_API_KEY in backend/.env.
    - Continues to require DATABASE_URL, DB_USER, JWT_SECRET (optional empty DB_PASSWORD).

- How To Test:
    - Set env: OPENAI_API_KEY, DB vars; cd backend && npm start.
    - Sign up/login, generate or select a map.
    - Open the Chat panel, try prompts:
    - “Suggest improvements to component placement.”
    - “Add a component ‘Monitoring’ at evolution 0.6, visibility 0.7.”
    - “Link ‘User’ to ‘Auth’.”
- Verify: assistant reply appears, canvas updates, reload map to confirm persistence, GET /maps/:id/chat returns history.
Verify: assistant reply appears, canvas updates, reload map to confirm persistence, GET /maps/:id/chat returns history.

- Known Limitations:
    - Responses are non-streaming (plain JSON roundtrip).
    - AI commands are best-effort; strict JSON parsing and clamping applied.
    - Rate limits/errors from OpenAI are surfaced as 500 with details.

- Checklist:
    - Env vars set (OPENAI_API_KEY, DB).
    - DB reachable; server starts without migration errors.
    - Generated/edited maps still work as before.
    - README and AGENTS updated for Phase 4.