### PR TITLE
feat(landing+guides): add signed-out landing explainer and signed-in …

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -33,9 +33,10 @@ async function init() {
   $('logoutBtn').addEventListener('click', logout);
   $('logoutSidebar').addEventListener('click', logout);
   $('profileBtn').addEventListener('click', () => alert('Profile coming soon'));
+  const guidesBtn = $('guidesBtn'); if (guidesBtn) guidesBtn.addEventListener('click', showGuides);
   $('newMapBtn').addEventListener('click', () => {
     currentMapId = null; components = []; links = []; selectedComponentId = null;
-    $('generatorView').classList.remove('hidden'); $('editorView').classList.add('hidden');
+    $('generatorView').classList.remove('hidden'); $('editorView').classList.add('hidden'); $('guidesView')?.classList.add('hidden');
     renderMap();
   });
 
@@ -139,7 +140,7 @@ async function deleteMap(m) {
   const res = await fetch(API + `/maps/${m.id}`, { method:'DELETE', headers:{ 'Authorization': 'Bearer '+localStorage.getItem('token') } });
   if (!res.ok) { alert('Delete failed'); return; }
   mapsList = mapsList.filter(x=>x.id!==m.id); renderMapList();
-  if (currentMapId===m.id) { currentMapId=null; components=[]; links=[]; $('editorView').classList.add('hidden'); $('generatorView').classList.remove('hidden'); renderMap(); }
+  if (currentMapId===m.id) { currentMapId=null; components=[]; links=[]; $('editorView').classList.add('hidden'); $('guidesView')?.classList.add('hidden'); $('generatorView').classList.remove('hidden'); renderMap(); }
 }
 
 // Generator
@@ -152,7 +153,7 @@ async function generateMapFromPrompt() {
     $('genStatus').textContent = `Map generated: ${data.name || ''}`;
     currentMapId = data.id; components = (data.components||[]).map(c=>({ ...c })); links = (data.links||[]).map(l=>({ ...l }));
     $('mapTitle').textContent = data.name || 'Map'; $('mapUpdated').textContent = 'Just now';
-    $('generatorView').classList.add('hidden'); $('editorView').classList.remove('hidden');
+    $('generatorView').classList.add('hidden'); $('editorView').classList.remove('hidden'); $('guidesView')?.classList.add('hidden');
     await populateMaps();
     renderMap();
     await loadChat();
@@ -165,7 +166,7 @@ async function loadMap(id) {
   const data = await res.json(); if (!res.ok) return;
   currentMapId = id; components = (data.components||[]).map(c=>({ ...c })); links = (data.links||[]).map(l=>({ ...l }));
   $('mapTitle').textContent = data.name || 'Map'; $('mapUpdated').textContent = data.description ? data.description : '';
-  $('generatorView').classList.add('hidden'); $('editorView').classList.remove('hidden');
+  $('generatorView').classList.add('hidden'); $('editorView').classList.remove('hidden'); $('guidesView')?.classList.add('hidden');
   renderMap();
   await loadChat();
 }
@@ -307,6 +308,13 @@ async function sendChatMessage() {
 function appendChat(role, content) {
   const log = $('chatLog'); const div = document.createElement('div');
   div.className = role === 'assistant' ? 'mb-2' : 'mb-2'; div.textContent = `${role}: ${content}`; log.appendChild(div); log.scrollTop = log.scrollHeight;
+}
+
+function showGuides() {
+  const g = $('guidesView'); if (!g) return;
+  $('generatorView')?.classList.add('hidden');
+  $('editorView')?.classList.add('hidden');
+  g.classList.remove('hidden');
 }
 
 if (document.readyState === 'loading') {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,21 @@
     </div>
   </header>
   <main class="container px-4 py-4">
-    <div id="auth" class="space-y-4">
+    <div id="auth" class="space-y-6">
+      <div class="card p-4">
+        <h2 class="text-xl font-semibold mb-2">Understand, Strategize, Decide — with Wardley Maps</h2>
+        <div class="prose">
+          <p>Wardley maps visualize your landscape: users, components, dependencies, and evolution. Use them to spot inertia, guide investment, and make confident decisions.</p>
+          <ul class="list-disc pl-5">
+            <li>Describe a system to generate a first map.</li>
+            <li>Drag components to refine positions and links.</li>
+            <li>Chat with AI for analysis and next steps.</li>
+          </ul>
+          <p>Learn more: <a class="text-blue-600 underline" href="https://wardleymaps.com/" target="_blank" rel="noopener">wardleymaps.com</a> ·
+          <a class="text-blue-600 underline" href="https://www.youtube.com/results?search_query=wardley+maps" target="_blank" rel="noopener">YouTube talks</a> ·
+          <a class="text-blue-600 underline" href="https://leadingedgeforum.com/research/wardley-maps/" target="_blank" rel="noopener">LEF intro</a></p>
+        </div>
+      </div>
       <div class="grid md:grid-cols-2 gap-6">
         <form id="signupForm" class="space-y-3 card p-4">
           <h2 class="text-xl">Sign Up</h2>
@@ -46,6 +60,7 @@
         <input id="mapSearch" class="border p-2 rounded w-full mb-2" placeholder="Search maps..." />
         <ul id="mapsList" class="map-list"></ul>
         <hr class="my-4" />
+        <button id="guidesBtn" class="btn btn-tonal w-full mb-2"><span class="material-symbols-outlined">menu_book</span>Guides</button>
         <button id="profileBtn" class="btn btn-tonal w-full mb-2"><span class="material-symbols-outlined">account_circle</span>Profile</button>
         <button id="logoutSidebar" class="btn btn-tonal w-full"><span class="material-symbols-outlined">logout</span>Logout</button>
       </aside>
@@ -88,6 +103,29 @@
               <button id="sendChat" class="btn btn-primary"><span class="material-symbols-outlined">send</span>Send</button>
             </div>
             <div id="chatStatus" class="text-sm text-gray-600 mt-1"></div>
+          </div>
+        </div>
+        <div id="guidesView" class="hidden card p-4">
+          <h3 class="text-xl font-semibold mb-2">Guides: Wardley Mapping</h3>
+          <div class="prose">
+            <h4>What is a Wardley Map?</h4>
+            <p>A Wardley Map is a visual model of a system showing the value chain (Y axis: visibility to users) and evolution (X axis: from genesis to commodity). It helps you reason about strategy and movement.</p>
+            <h4>How to Create</h4>
+            <ul class="list-disc pl-5">
+              <li>Define users and their needs (top of value chain).</li>
+              <li>List components that fulfill those needs.</li>
+              <li>Place components by evolution (X) and visibility (Y).</li>
+              <li>Connect components to show dependencies.</li>
+            </ul>
+            <h4>How to Use</h4>
+            <ul class="list-disc pl-5">
+              <li>Identify duplication, inertia, and opportunities.</li>
+              <li>Choose plays (e.g., build vs buy, open vs proprietary).</li>
+              <li>Track movement over time to inform decisions.</li>
+            </ul>
+            <p>Deep dives: <a class="text-blue-600 underline" href="https://wardleypedia.org/" target="_blank" rel="noopener">Wardleypedia</a> ·
+            <a class="text-blue-600 underline" href="https://www.youtube.com/results?search_query=wardley+maps" target="_blank" rel="noopener">YouTube</a> ·
+            <a class="text-blue-600 underline" href="https://medium.com/wardleymaps" target="_blank" rel="noopener">Wardley Maps on Medium</a></p>
           </div>
         </div>
       </section>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -53,3 +53,9 @@ body { background: var(--bg); font-family: Roboto, system-ui, -apple-system, Seg
 .border { border: 1px solid var(--border); }
 .rounded { border-radius: 8px; }
 header.appbar { position: sticky; top: 0; z-index: 10; background: #ffffffcc; backdrop-filter: saturate(180%) blur(12px); border-bottom: 1px solid var(--border); }
+
+/* Simple prose formatting */
+.prose h4 { font-size: 1rem; font-weight: 600; margin-top: 8px; margin-bottom: 4px; }
+.prose p { margin: 6px 0; color: var(--text); }
+.prose ul { margin: 6px 0; }
+.prose a:hover { text-decoration-thickness: 2px; }


### PR DESCRIPTION
- Signed-out landing:
    - Adds a concise explainer card above the signup/login forms.
    - Includes quick bullets on how to use the app and links to learn more (wardleymaps.com, YouTube, LEF).
- Signed-in Guides:
    - Sidebar “Guides” button (guidesBtn) switches the main pane to a Guides view.
    - Guides cover: what Wardley Maps are, how to create them, and how to use them; links to Wardleypedia, YouTube, Medium.
    - Generator and Editor views hide when Guides are open; toggling back via “New” or selecting a map restores previous flows.
- Styling:
    - Adds a prose class to styles.css for readable headings, lists, and links in the Guides and landing content.

Files Changed

- frontend/index.html: Landing explainer, sidebar Guides button, Guides view section.
- frontend/app.js: Guides button handler, showGuides() function, consistent view toggling (hide Guides when switching to generator/editor).
- frontend/styles.css: Prose formatting; minor list and link styles.

Try It

- Start backend: cd backend && npm start
- Visit http://localhost:3000
- Signed-out: See landing explainer + auth forms.
- Signed-in: Use sidebar “Guides” to view documentation; “New” for generator; select a map for editor.